### PR TITLE
 A couple bug fixes and a small feature

### DIFF
--- a/Plugins/Tweener/Source/Tweener/Private/Tween.cpp
+++ b/Plugins/Tweener/Source/Tweener/Private/Tween.cpp
@@ -1247,6 +1247,7 @@ void UTween::HandleLooping()
 	if (LoopType == ELoopType::RestartFromBeginning || Loops % 2 == 1)
 	{
 		LoopComplete.Broadcast();
+		LoopCompleteDelegate.Broadcast();
 	}
 
 	// kill our loop if we have no loops left and zero out the delay then prepare for use

--- a/Plugins/Tweener/Source/Tweener/Private/Tween.cpp
+++ b/Plugins/Tweener/Source/Tweener/Private/Tween.cpp
@@ -223,7 +223,7 @@ UTween* UTween::ComponentRelativeScaleTo(USceneComponent* SceneComponent, FVecto
 	bool bIsScaleRelative, float Duration, EEaseType EaseType, ELoopType LoopType, int32 Loops, 
 	float DelayBetweenLoops, const UObject* WorldContextObject)
 {
-	return NewTweenSceneComponent(SceneComponent, ETweenType::Scale, FVector4(Scale), bIsScaleRelative, 
+	return NewTweenSceneComponent(SceneComponent, ETweenType::RelativeScale, FVector4(Scale), bIsScaleRelative, 
 		Duration, EaseType, LoopType, Loops, DelayBetweenLoops, WorldContextObject);
 }
 
@@ -231,7 +231,7 @@ UTween* UTween::ComponentRelativeScaleFrom(USceneComponent* SceneComponent, FVec
 	bool bIsScaleRelative, float Duration, EEaseType EaseType, ELoopType LoopType, int32 Loops, 
 	float DelayBetweenLoops, const UObject* WorldContextObject)
 {
-	return NewTweenSceneComponentFrom(SceneComponent, ETweenType::Scale, FVector4(Scale), bIsScaleRelative,
+	return NewTweenSceneComponentFrom(SceneComponent, ETweenType::RelativeScale, FVector4(Scale), bIsScaleRelative,
 		Duration, EaseType, LoopType, Loops, DelayBetweenLoops, WorldContextObject);
 }
 

--- a/Plugins/Tweener/Source/Tweener/Private/TweenerSubsystem.cpp
+++ b/Plugins/Tweener/Source/Tweener/Private/TweenerSubsystem.cpp
@@ -40,6 +40,7 @@ void UTweenerSubsystem::Tick(float DeltaTime)
 		if (!Tween->ObjectPtr.IsValid() || Tween->Tick(DeltaTime, UnscaledDeltaTime))
 		{
 			Tween->Complete.Broadcast();
+			Tween->CompleteDelegate.Broadcast();
 
 			//// handle nextTween if we have a chain
 			if (Tween->NextTween != nullptr)
@@ -90,6 +91,7 @@ bool UTweenerSubsystem::StopTween(UTween* Tween, bool bBringToCompletion, bool b
 				}
 
 				TweenItr->Complete.Broadcast();
+				TweenItr->CompleteDelegate.Broadcast();
 			}
 
 			//Every linked tween after the active tween will need to be Completed
@@ -121,6 +123,7 @@ bool UTweenerSubsystem::StopTweenForObject(UObject *Object, bool bBringToComplet
 				Tween->Tick(0.f, 0.f, true);
 
 				Tween->Complete.Broadcast();
+				Tween->CompleteDelegate.Broadcast();
 			}
 
 			ActiveTweens.RemoveAt(Index);
@@ -142,6 +145,7 @@ void UTweenerSubsystem::StopAllTweens(bool bBringToCompletion)
 				ActiveTween->Tick(0.f, 0.f, true);
 
 				ActiveTween->Complete.Broadcast();
+				ActiveTween->CompleteDelegate.Broadcast();
 			}
 		}
 	}

--- a/Plugins/Tweener/Source/Tweener/Private/TweenerSubsystem.cpp
+++ b/Plugins/Tweener/Source/Tweener/Private/TweenerSubsystem.cpp
@@ -96,7 +96,7 @@ bool UTweenerSubsystem::StopTween(UTween* Tween, bool bBringToCompletion, bool b
 			bFoundActive = true;
 		}
 
-		TweenItr = bBringToCompletion && bIncludeChain ? TweenItr->NextTween : nullptr;
+		TweenItr = bIncludeChain ? TweenItr->NextTween : nullptr;
 	}
 
 	return bFoundActive;

--- a/Plugins/Tweener/Source/Tweener/Public/Tween.h
+++ b/Plugins/Tweener/Source/Tweener/Public/Tween.h
@@ -100,6 +100,7 @@ enum class ETargetValueType : uint8
 };
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FTweenOutputPin);
+DECLARE_MULTICAST_DELEGATE(FTweenDelegate);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FTweenCustomAction, UObject*,Object,float,EasedValue,float,Value);
 
@@ -472,9 +473,11 @@ public:
 	
 	UPROPERTY(BlueprintAssignable)
 	FTweenOutputPin Complete;
+	FTweenDelegate CompleteDelegate; // Non-dynamic version
 
 	UPROPERTY(BlueprintAssignable)
 	FTweenOutputPin LoopComplete;
+	FTweenDelegate LoopCompleteDelegate; // Non-dynamic version
 	
 	// internal state
 


### PR DESCRIPTION
(I'm submitting the PR again because this is the only way to change the source branch and I needed master for something else. Sorry)

Hi! I'm merging back some changes that we made as we were using Tweener in our project.

This fixes two bugs: 
* One where ComponentRelativeScaleTo/From would tween the absolute scale instead
* And one where chained tweens would leak memory if their parent was stopped without bringing to completion

This also adds non-dynamic versions of the completion delegates, which makes it much easier to use from C++, since non-dynamic delegates also support binding to lambdas and other things (and are also a bit faster).

Tell me if you want these in separate PRs.